### PR TITLE
Fix for newer browsers

### DIFF
--- a/enabled.html
+++ b/enabled.html
@@ -62,12 +62,12 @@
  });</pre>   
     </code>
 
-    <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
-    <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
-    <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
-    <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
-    <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
-    <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
+    <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
+    <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
+    <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
+    <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
+    <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
+    <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
 
     </div>
     <div id="sidebar">

--- a/enabled_container.html
+++ b/enabled_container.html
@@ -67,12 +67,12 @@
     </code>
 
     <div id="container">
-        <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
-        <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
-        <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
-        <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
-        <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
-        <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
+        <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
+        <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
+        <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
+        <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
+        <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
+        <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
     </div>
 
     </div>

--- a/enabled_fadein.html
+++ b/enabled_fadein.html
@@ -66,12 +66,12 @@
  });</pre>
     </code>
 
-    <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
-    <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
-    <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
-    <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
-    <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
-    <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
+    <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
+    <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
+    <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
+    <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
+    <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
+    <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
 
     </div>
     <div id="sidebar">

--- a/enabled_timeout.html
+++ b/enabled_timeout.html
@@ -74,12 +74,12 @@
      </pre>
     </code>    
 
-    <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
-    <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
-    <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
-    <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
-    <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
-    <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
+    <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood"><br/>
+    <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side"><br/>
+    <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1"><br/>
+    <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner"><br/>
+    <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT"><br/>
+    <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop"><br/>
 
     </div>
     <div id="sidebar">

--- a/enabled_wide.html
+++ b/enabled_wide.html
@@ -62,12 +62,12 @@
  });</pre>     
     </code>
 
-    <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood">
-    <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side">
-    <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1">
-    <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner">
-    <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT">
-    <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop">
+    <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood">
+    <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side">
+    <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1">
+    <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner">
+    <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT">
+    <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop">
     
     </div>
     <div id="sidebar">

--- a/enabled_wide_container.html
+++ b/enabled_wide_container.html
@@ -73,12 +73,12 @@
 
     <div id="container">
         <div id="inner_container">
-            <img src="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood">
-            <img src="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side">
-            <img src="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1">
-            <img src="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner">
-            <img src="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT">
-            <img src="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop">
+            <img original="img/bmw_m1_hood.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Hood">
+            <img original="img/bmw_m1_side.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M1 Side">
+            <img original="img/viper_1.jpg?<?php print time() ?>" width="765" height="574" alt="Viper 1">
+            <img original="img/viper_corner.jpg?<?php print time() ?>" width="765" height="574" alt="Viper Corner">
+            <img original="img/bmw_m3_gt.jpg?<?php print time() ?>" width="765" height="574" alt="BMW M3 GT">
+            <img original="img/corvette_pitstop.jpg?<?php print time() ?>" width="765" height="574" alt="Corvette Pitstop">
         </div>
     </div>
     

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -57,11 +57,6 @@
         this.each(function() {
             var self = this;
             
-            /* Save original only if it is not defined in HTML. */
-            if (undefined == $(self).attr("original")) {
-                $(self).attr("original", $(self).attr("src"));     
-            }
-
             if ("scroll" != settings.event || 
                     undefined == $(self).attr("src") || 
                     settings.placeholder == $(self).attr("src") || 


### PR DESCRIPTION
I took a look at the issue. It appears that newer browsers\* are pre-loading images as they find <img src=''/>. I'm guessing that this happens as they are parsing the HTML. So once jQuery Lazy Load runs, the images are already being downloaded (or queued for downloading) by the browser. The only reasonable solution that I could think of is to force people to use the <img original=''/> syntax (or maybe better renamed <img lazy=''/>). The one problem is that there is no graceful fallback if JavaScript is disabled. Not sure if there is any solution here.
