### PR TITLE
Bugfix on IE7

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -77,7 +77,12 @@
                 }
                 self.loaded = false;
             } else {
-                self.loaded = true;
+                if ("" == $(self).attr("src")) {
+                    self.loaded = false
+                }
+                else {                  
+                    self.loaded = true;
+                }
             }
             
             /* When appear is triggered load original image. */


### PR DESCRIPTION
Fixed a bug on IE7, it appears that when src has no content (when using original attribute), the $(self).attr("src") returns an empty string instead of undefined, so all the visible images that have to be loaded were having a loaded true attribute, so no loading.
It fixes that.
