### PR TITLE
Add data_attribute option to allow customization of image url attribute

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -21,6 +21,7 @@
             event           : "scroll",
             effect          : "show",
             container       : window,
+            data_attribute  : "original",
             skip_invisible  : true
         };
                 
@@ -74,11 +75,11 @@
                         .bind("load", function() {
                             $(self)
                                 .hide()
-                                .attr("src", $(self).data("original"))
+                                .attr("src", $(self).data(settings.data_attribute))
                                 [settings.effect](settings.effectspeed);
                             self.loaded = true;
                         })
-                        .attr("src", $(self).data("original"));
+                        .attr("src", $(self).data(settings.data_attribute));
                 };
             });
 


### PR DESCRIPTION
Hi,

Thanks for releasing jquery.lazyload! Here is a simple, backwards-compatible patch that adds an option to allow the calling code to specify the name of the data attribute containing the original image URL.

I wrote this because I needed to apply lazyload to an app with lots of legacy markup with the image URLs contained in data-src attributes.

Cheers,
Bryan
