### PR TITLE
My usual two cents performance – albeit this is only a comment ;)

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -193,7 +193,7 @@
      };
 
     /* Custom selectors for your convenience.   */
-    /* Use as $("img:below-the-fold").something() */
+    /* Use as $("img").filter(":below-the-fold").something() */
 
     $.extend($.expr[':'], {
         "below-the-fold" : function(a) { return $.belowthefold(a, {threshold : 0, container: window}); },


### PR DESCRIPTION
One should avoid using jQuery proprietary selector extensions for performance reasons (thus enabling the use of native selector implementations by jQuery in the background) and use `filter()` instead.
