### PR TITLE
jQuery < 1.4.3 compatibility

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -95,7 +95,7 @@
                         .bind("load", function() {
                             $self
                                 .hide()
-                                .attr("src", $self.data(settings.data_attribute))
+                                .attr("src", $self.data(settings.data_attribute) || $self.attr('data-' + settings.data_attribute))
                                 [settings.effect](settings.effect_speed);
                             self.loaded = true;
 
@@ -110,7 +110,7 @@
                                 settings.load.call(self, elements_left, settings);
                             }
                         })
-                        .attr("src", $self.data(settings.data_attribute));
+                        .attr("src", $self.data(settings.data_attribute) || $self.attr('data-' + settings.data_attribute));
                 }
             });
 


### PR DESCRIPTION
Before 1.4.3 data() did not include HTML5 data-\* attributes.
Tested with jQuery 1.4.2
