### PR TITLE
$(window).height() cannot get correct value after scroll down in ios

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -143,7 +143,7 @@
         var fold;
         
         if (settings.container === undefined || settings.container === window) {
-            fold = $window.height() + $window.scrollTop();
+            fold = (window.innerHeight ? window.innerHeight : $window.height()) + $window.scrollTop();
         } else {
             fold = $(settings.container).offset().top + $(settings.container).height();
         }


### PR DESCRIPTION
Hi tuupola:

window's height in ios is dynamic, window's height will increase after user scroll down, because url bar will be hidden.
$(window).height() cannot get correct value, use (window.innerHeight ? window.innerHeight : $window.height()) instead.

YUI lazy load also have same problem. I tried the  demo page in my iphone and ipad (ios5 without JB).

Thanks.
Girvan
