### PR TITLE
Fix :in-viewport

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -188,7 +188,7 @@
     };
 
     $.inviewport = function(element, settings) {
-         return !$.rightofscreen(element, settings) && !$.leftofscreen(element, settings) && 
+         return !$.rightoffold(element, settings) && !$.leftofbegin(element, settings) &&
                 !$.belowthefold(element, settings) && !$.abovethetop(element, settings);
      };
 
@@ -200,7 +200,7 @@
         "above-the-top"  : function(a) { return !$.belowthefold(a, {threshold : 0}); },
         "right-of-screen": function(a) { return $.rightoffold(a, {threshold : 0}); },
         "left-of-screen" : function(a) { return !$.rightoffold(a, {threshold : 0}); },
-        "in-viewport"    : function(a) { return !$.inviewport(a, {threshold : 0}); },
+        "in-viewport"    : function(a) { return $.inviewport(a, {threshold : 0}); },
         /* Maintain BC for couple of versions. */
         "above-the-fold" : function(a) { return !$.belowthefold(a, {threshold : 0}); },
         "right-of-fold"  : function(a) { return $.rightoffold(a, {threshold : 0}); },


### PR DESCRIPTION
That function was using `rightofscreen` and `leftofscreen` which, I'm assuming, are legacy names.

Also, the `!` was inverting the logic.
