### PR TITLE
Fix: Initial scroll needed in chrome version 22.0.1229.94 to load imgs

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -133,7 +133,8 @@
         });
 
         /* Force initial check if images should appear. */
-        $(document).ready(function() {
+        /* had to change this to $(window) so this fix would work for Chrome Version 22.0.1229.94 */
+        $(window).ready(function() {
             update();
         });
         


### PR DESCRIPTION
https://github.com/tuupola/jquery_lazyload/pull/48# 
Was still happening for me. 
In Chrome version 22.0.1229.94 if page loaded and images were in view it would not load images until an initial scroll was made.
I wrapped the initial update() call around a window.ready and it seems to have fixed it.
