### PR TITLE
event.originalEvent check 

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -136,7 +136,7 @@
         /* Non optimal workaround. */
         if ((/iphone|ipod|ipad.*os 5/gi).test(navigator.appVersion)) {
             $window.bind("pageshow", function(event) {
-                if (event.originalEvent.persisted) {
+                if (event.originalEvent && event.originalEvent.persisted) {
                     elements.each(function() {
                         $(this).trigger("appear");
                     });


### PR DESCRIPTION
There is bug:
Uncaught TypeError: Cannot read property 'persisted' of undefined 

When f.e. using 

`<script src="/bzJApp/views/filever111/site/mobileModnique/mobileResources/js/jquery/infinitescroll.min.js"></script>
`

which rewrites scroll trigger.
