### PR TITLE
Fixing support for multiple event bindings

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -74,10 +74,8 @@
                       settings.container === window) ? $window : $(settings.container);
 
         /* Fire one scroll event per scroll. Not one scroll event per image. */
-        if (0 === settings.event.indexOf("scroll")) {
-            $container.bind(settings.event, function(event) {
-                return update();
-            });
+        if (0 <= settings.event.indexOf("scroll")) {
+            $container.bind("scroll", update);
         }
 
         this.each(function() {
@@ -123,8 +121,8 @@
 
             /* When wanted event is triggered load original image */
             /* by triggering appear.                              */
-            if (0 !== settings.event.indexOf("scroll")) {
-                $self.bind(settings.event, function(event) {
+            if ($.trim(settings.event.replace("scroll","")) !== "") {
+                $self.bind(settings.event.replace("scroll",""), function(event) {
                     if (!self.loaded) {
                         $self.trigger("appear");
                     }
@@ -133,9 +131,7 @@
         });
 
         /* Check if something appears when window is resized. */
-        $window.bind("resize", function(event) {
-            update();
-        });
+        $window.bind("resize", update);
               
         /* With IOS5 force loading images when navigating with back button. */
         /* Non optimal workaround. */
@@ -150,9 +146,7 @@
         }
 
         /* Force initial check if images should appear. */
-        $(window).load(function() {
-            update();
-        });
+        $(window).load(update);
         
         return this;
     };

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -27,7 +27,8 @@
             data_attribute  : "original",
             skip_invisible  : true,
             appear          : null,
-            load            : null
+            load            : null,
+            error_callback  : $.noop()
         };
 
         function update() {
@@ -114,6 +115,10 @@
                                 var elements_left = elements.length;
                                 settings.load.call(self, elements_left, settings);
                             }
+                        })
+                        .bind("error", error_data, function() {
+                            /* this should always work, since the default value is $.noop() */
+                            settings.error_callback(error_data);
                         })
                         .attr("src", $self.data(settings.data_attribute));
                 }


### PR DESCRIPTION
Previously, the code assumed that the 'scroll' event was first in the settings.event property.
I changed this to check if it's in the property string or not.
I also changed the other event bindings to remove 'scroll' from the list if it exists, since we already binded to it previously.
