### PR TITLE
Background images added

### DIFF
--- a/background_image.html
+++ b/background_image.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>Lazy Load Enabled</title>
+  <meta name="generator" content="Mephisto" />
+  <link rel="alternate" type="application/atom+xml" href="http://feeds.feedburner.com/tuupola" title="Atom feed" />
+  <link href="http://www.appelsiini.net/stylesheets/main2.css" rel="stylesheet" type="text/css" />
+  <style type="text/css">
+  #sidebar {
+    width: 0px;
+  }
+
+  #content {
+    width: 770px;
+  }
+  
+  .lazyload {
+    background-image: url(img/grey.gif);
+    height: 574px;
+    width: 765px;
+    margin-bottom: 20px;
+  }
+  </style>
+
+  <script>
+  var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-190966-1']);
+      _gaq.push(['_trackPageview']);
+      _gaq.push(['_trackPageLoadTime']);
+    
+  (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+  </script>
+</head>
+
+<body>    
+  <div id="wrap"> 
+    <div id="header">
+      <p>
+        <h1>Lazy Load</h1><br />
+        <small>Image lazy loader plugin for jQuery.</small>
+        <ul id="nav">
+          <li id="first"><a href="/" class="active">weblog</a></li>
+          <li><a href="/projects" class="last">projects</a></li>
+          <!--
+          <li><a href="/cv" class="last">cv</a></li>
+        -->
+        </ul>
+      </p>
+    </div>
+    <div id="content">
+      
+  <h2>Background Images</h2>
+  <div class="entry">
+    
+    <p>
+      Images are loaded into divs via the background-image selector rather than img tags. 
+      The divs are given a class of "lazyload" and when when scrolling down they are 
+      loaded when needed. Empty cache and shift-reload to test again.
+    </p>
+
+    <code>
+      <pre>
+ $(".lazyload").lazyload();</pre>   
+    </code>
+
+    <div class="lazyload" data-original="img/bmw_m1_hood.jpg"></div>
+    <div class="lazyload" data-original="img/bmw_m1_side.jpg"></div>
+    <div class="lazyload" data-original="img/viper_1.jpg"></div>
+    <div class="lazyload" data-original="img/viper_corner.jpg"></div>
+    <div class="lazyload" data-original="img/bmw_m3_gt.jpg"></div>
+    <div class="lazyload" data-original="img/corvette_pitstop.jpg"></div>
+
+    </div>
+    <div id="sidebar">
+
+  </div>
+  
+  <div id="footer">
+  </div>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js" charset="utf-8"></script>
+  <script src="jquery.lazyload.js?v=1.8.3" charset="utf-8"></script>
+  <script type="text/javascript" charset="utf-8">
+      $(function() {
+          $(".lazyload").lazyload();
+      });
+  </script>
+</body>
+</html>

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -32,7 +32,7 @@
 
         function update() {
             var counter = 0;
-      
+
             elements.each(function() {
                 var $this = $(this);
                 if (settings.skip_invisible && !$this.is(":visible")) {
@@ -55,7 +55,7 @@
 
         }
 
-        if(options) {
+        if (options) {
             /* Maintain BC for a couple of versions. */
             if (undefined !== options.failurelimit) {
                 options.failure_limit = options.failurelimit; 
@@ -93,26 +93,31 @@
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
                     }
-                    $("<img />")
-                        .bind("load", function() {
-                            $self
-                                .hide()
-                                .attr("src", $self.data(settings.data_attribute))
-                                [settings.effect](settings.effect_speed);
-                            self.loaded = true;
 
-                            /* Remove image from array so it is not looped next time. */
-                            var temp = $.grep(elements, function(element) {
-                                return !element.loaded;
-                            });
-                            elements = $(temp);
+                    if ($self.is('img')) {
+                        $("<img />")
+                            .bind("load", function() {
+                                $self
+                                    .hide()
+                                    .attr("src", $self.data(settings.data_attribute))
+                                    [settings.effect](settings.effect_speed);
+                                self.loaded = true;
 
-                            if (settings.load) {
-                                var elements_left = elements.length;
-                                settings.load.call(self, elements_left, settings);
-                            }
-                        })
-                        .attr("src", $self.data(settings.data_attribute));
+                                /* Remove image from array so it is not looped next time. */
+                                var temp = $.grep(elements, function(element) {
+                                    return !element.loaded;
+                                });
+                                elements = $(temp);
+
+                                if (settings.load) {
+                                    var elements_left = elements.length;
+                                    settings.load.call(self, elements_left, settings);
+                                }
+                            })
+                            .attr("src", $self.data(settings.data_attribute));
+                    } else {
+                        $self.css('backgroundImage', 'url(' + $self.data(settings.data_attribute) + ')');
+                    }
                 }
             });
 


### PR DESCRIPTION
I've added the ability to lazyload images that are added via the background-image selector. I've been using lazyload for a while and with every project I've needed this, so I decided just to do it myself. A couple of points:
- Animations with background images do not work. This was not something I personally needed, but I'm guessing it can be done, even if just via CSS animations.
- Images are loaded via the "data-original" attribute. This attribute is read and converted into an inline style call to background-image.
- I also created a demo page called background_image.html.
