### PR TITLE
event.originalEvent is not always defined on iOS and jQuery 1.9.0

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -136,7 +136,7 @@
         /* Non optimal workaround. */
         if ((/iphone|ipod|ipad.*os 5/gi).test(navigator.appVersion)) {
             $window.bind("pageshow", function(event) {
-                if (event.originalEvent.persisted) {
+                if (event.originalEvent && event.originalEvent.persisted) {
                     elements.each(function() {
                         $(this).trigger("appear");
                     });


### PR DESCRIPTION
This one line patch just makes sure that it is defined. I had the problem on iOS running 6.1.3, using the lazyload plugin and not scrollstop, under jQuery 1.9.0.
