### PR TITLE
Fix memory leak in the case of AJAX navigation

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -53,6 +53,12 @@
                 }
             });
 
+            /* Remove images that are not on the page */
+            var temp = $.grep(elements, function(element) {
+                return document.contains(element);
+            });
+            elements = $(temp);
+
         }
 
         if(options) {


### PR DESCRIPTION
Fix memory leak by removing images that are not on the page (e.g. were replace by new ones using AJAX).

PS. It would be nice to have a public access to `elements` (to modify it after DOM updates instead of having a lot of $().lazyload instances)
