### PR TITLE
Added "wait" into settings. This setting specifies the number of milliseconds wait before loading a image.

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -21,6 +21,7 @@
         var $container;
         var settings = {
             threshold       : 0,
+            wait            : 0,
             failure_limit   : 0,
             event           : "scroll",
             effect          : "show",
@@ -94,8 +95,29 @@
             }
             
             /* When appear is triggered load original image. */
-            $self.one("appear", function() {
+            var replace_src = function(event, waited) {
                 if (!this.loaded) {
+                    /* Wait before loading image if needed. */
+                    if (settings.wait > 0) {
+                        if (! waited) {
+                            setTimeout(function() { replace_src(event, true); }, settings.wait);
+                            return;
+                        } else {
+                            // triggered from setTimeout.
+                            // Check image is still in viewport.
+
+                            if ($.abovethetop($self, settings) ||
+                                $.leftofbegin($self, settings) ||
+                                $.belowthefold($self, settings) ||
+                                $.rightoffold($self, settings)) {
+                                // Do not load image. Restore a handler.
+                                $self.one("appear", replace_src);
+                                return;
+                            }
+                        }
+                    }
+
+                    /* Load image */
                     if (settings.appear) {
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
@@ -126,7 +148,8 @@
                         })
                         .attr("src", $self.data(settings.data_attribute));
                 }
-            });
+            };
+            $self.one("appear", replace_src);
 
             /* When wanted event is triggered load original image */
             /* by triggering appear.                              */


### PR DESCRIPTION
# Problem

When user moves to the bottom of the page with animation, all images are loaded at the same time.

For example, push "scroll to bottom" button in https://pqrs.org/tmp/jquery_lazyload/ ,
all images (assets/red1x1_000.png - assets/red1x1_029.png) are loaded while scrolling.
# Solution

I've added "wait" into settings.
If "wait" > 0, a image will be loaded if it shown "wait" milliseconds continuously.

Demo:
https://pqrs.org/tmp/jquery_lazyload/index.mod.html
In this page, a image is loaded if it shown 300ms or more.
