### PR TITLE
Fix dynamically added images to be loaded if inside the viewport

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -128,6 +128,11 @@
                 }
             });
 
+            /* For dynamically added images, trigger appear when added inside the viewport */
+            if ($.isReady && $.inviewport($self, settings)) {
+                $self.trigger("appear");
+            }
+
             /* When wanted event is triggered load original image */
             /* by triggering appear.                              */
             if (0 !== settings.event.indexOf("scroll")) {


### PR DESCRIPTION
I've noticed that dynamically added images (after the document.ready event) will not load directly, only after a scroll or resize action.

With this fix, those images get to be loaded without the need of a scroll event.
