### PR TITLE
If the element will be displayed without any animation there is no need hide & show it instantly.

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -104,15 +104,22 @@
                     }
                     $("<img />")
                         .bind("load", function() {
+                            var original = $self.attr("data-" + settings.data_attribute),
+                                isAnimated = settings.effect !== "show";
 
-                            var original = $self.attr("data-" + settings.data_attribute);
-                            $self.hide();
+                            if (isAnimated) {
+                                $self.hide();
+                            }
+
                             if ($self.is("img")) {
                                 $self.attr("src", original);
                             } else {
                                 $self.css("background-image", "url('" + original + "')");
                             }
-                            $self[settings.effect](settings.effect_speed);
+
+                            if (isAnimated) {
+                                $self[settings.effect](settings.effect_speed);
+                            }
 
                             self.loaded = true;
 


### PR DESCRIPTION
Hiding and showing it again instantly creates a small visual flicker on slow devices. As the image should be already be loaded in the background, I can't see any reason why it is necessary to hide & show it while setting it's src.
