### PR TITLE
if no data-original attribute is found, do not try to load it, and do nothing

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -102,32 +102,33 @@
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
                     }
-                    $("<img />")
-                        .bind("load", function() {
+	                  var original = $self.attr("data-" + settings.data_attribute);
+	                  if (undefined !== original)
+		                    $("<img />")
+		                        .bind("load", function() {
 
-                            var original = $self.attr("data-" + settings.data_attribute);
-                            $self.hide();
-                            if ($self.is("img")) {
-                                $self.attr("src", original);
-                            } else {
-                                $self.css("background-image", "url('" + original + "')");
-                            }
-                            $self[settings.effect](settings.effect_speed);
+		                            $self.hide();
+		                            if ($self.is("img")) {
+		                                $self.attr("src", original);
+		                            } else {
+		                                $self.css("background-image", "url('" + original + "')");
+		                            }
+		                            $self[settings.effect](settings.effect_speed);
 
-                            self.loaded = true;
+		                            self.loaded = true;
 
-                            /* Remove image from array so it is not looped next time. */
-                            var temp = $.grep(elements, function(element) {
-                                return !element.loaded;
-                            });
-                            elements = $(temp);
+		                            /* Remove image from array so it is not looped next time. */
+		                            var temp = $.grep(elements, function(element) {
+		                                return !element.loaded;
+		                            });
+		                            elements = $(temp);
 
-                            if (settings.load) {
-                                var elements_left = elements.length;
-                                settings.load.call(self, elements_left, settings);
-                            }
-                        })
-                        .attr("src", $self.attr("data-" + settings.data_attribute));
+		                            if (settings.load) {
+		                                var elements_left = elements.length;
+		                                settings.load.call(self, elements_left, settings);
+		                            }
+		                        })
+		                        .attr("src", original);
                 }
             });
 


### PR DESCRIPTION
let the optional function settings.appear do the job.

This allows to use script on elements that are not img with other loading methods
(such as container for adaptive image)
