### PR TITLE
Update jquery.lazyload.js

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -149,7 +149,7 @@
 
         /* With IOS5 force loading images when navigating with back button. */
         /* Non optimal workaround. */
-        if ((/(?:iphone|ipod|ipad).*os 5/gi).test(navigator.appVersion)) {
+        if ((/(?:iphone|ipod|ipad).*os [3-5]/gi).test(navigator.appVersion)) {
             $window.bind("pageshow", function(event) {
                 if (event.originalEvent && event.originalEvent.persisted) {
                     elements.each(function() {


### PR DESCRIPTION
images were not loading on my iphone 3G 
(mostly not at all!)

saw the workaround in there for iphone 5 so changed the regex slightly so it would also match iphone 3

That tiny change fixed it on my iphone 3G
 (default browser)
