### PR TITLE
Parent parameter

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -41,12 +41,11 @@
                 if (settings.skip_invisible && !$this.is(":visible")) {
                     return;
                 }
-                //console.log($this);
                 if ($.abovethetop($this, settings) ||
                     $.leftofbegin($this, settings)) {
                         /* Nothing. */
                 } else if (!$.belowthefold($this, settings) &&
-                    !$.rightoffold($this, settings)) { console.log('trigger');
+                    !$.rightoffold($this, settings)) {
                         $(this).trigger("appear");
                         /* if we found an image we'll load, reset the counter */
                         counter = 0;


### PR DESCRIPTION
adds optional parameter "parent". The idea is that if set you check that the parent is inviewport, and if so trigger the lazyload.

In my case I have a few sliders on a page, the slide elements are obviously always outside the viewport. Because of this currently the only option is to add an event, like slide change. I'd rather set it so that all slides get loaded when the parent slider becomes visible.
