### PR TITLE
Added support for retina images

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -8,7 +8,7 @@ Do not commit minified versions. Do not touch the version number. Make the pull 
 
 ## Follow the existing coding standards
 
-When contributing to open source project it is polite to follow the original authors coding standars. They might be different than yours. It is not a holy war. Just follow then original.
+When contributing to open source project it is polite to follow the original authors coding standars. They might be different than yours. It is not a holy war. Just follow the original.
 
 ```javascript
 var snake_case = "something";

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -33,7 +33,7 @@
             skip_invisible  : true,
             appear          : null,
             load            : null,
-            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+            placeholder     : "data:image/gif;base64,R0lGODdhAQABAPAAAMPDwwAAACwAAAAAAQABAAACAkQBADs="
         };
 
         var isRetina = window.devicePixelRatio && (window.devicePixelRatio > 1);
@@ -122,13 +122,23 @@
                                 imgUrl = original;
                             }
 
-                            $self.hide();
+                            if (settings.effect === 'fadeIn') {
+                                $self.css('opacity', 0);
+                            }
+                            else {
+                                $self.hide();
+                            }
                             if ($self.is("img")) {
                                 $self.attr("src", imgUrl);
                             } else {
                                 $self.css("background-image", "url('" + imgUrl + "')");
                             }
-                            $self[settings.effect](settings.effect_speed);
+                            if (settings.effect === 'fadeIn') {
+                                $self.fadeTo(100, settings.effect_speed);
+                            }
+                            else {
+                                $self[settings.effect](settings.effect_speed);
+                            }
 
                             self.loaded = true;
 

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -11,6 +11,9 @@
  *
  * Version:  1.9.3
  *
+ * NOTES:
+ *  1) Retina images are supported by adding the data-original-2x attribute.
+ *
  */
 
 (function($, window, document, undefined) {
@@ -26,11 +29,14 @@
             effect          : "show",
             container       : window,
             data_attribute  : "original",
+            data_attribute_2x  : "original-2x",
             skip_invisible  : true,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
         };
+
+        var isRetina = window.devicePixelRatio && (window.devicePixelRatio > 1);
 
         function update() {
             var counter = 0;
@@ -106,11 +112,21 @@
                         .bind("load", function() {
 
                             var original = $self.attr("data-" + settings.data_attribute);
+                            var original2x = $self.attr("data-" + settings.data_attribute_retina);
+                            var imgUrl;
+
+                            if (isRetina && original2x) {
+                                imgUrl = original2x;
+                            }
+                            else if (original) {
+                                imgUrl = original;
+                            }
+
                             $self.hide();
                             if ($self.is("img")) {
-                                $self.attr("src", original);
+                                $self.attr("src", imgUrl);
                             } else {
-                                $self.css("background-image", "url('" + original + "')");
+                                $self.css("background-image", "url('" + imgUrl + "')");
                             }
                             $self[settings.effect](settings.effect_speed);
 

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -138,7 +138,7 @@
                                                     height: $self.height(),
                                                     width: $self.width(),
                                                     backgroundImage: 'url(' + imgUrl + ')',
-                                                    background-size: '100% 100%',
+                                                    backgroundSize: '100% 100%',
                                                     opacity: 0
                                                    });
                                 $self.append($overlayChild);


### PR DESCRIPTION
Added support for retina images (via data attribute ‘data-original-2x’,
but attribute overrideable via option ‘data_attribute_2x’).  These are
loaded instead of the ‘original’ image if the display can show retina
images.

Also fixed a tiny typo on your 'Contributing' message. :+1: 
