### PR TITLE
one more placeholder case for blank src attribute

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -89,7 +89,7 @@
             self.loaded = false;
 
             /* If no src attribute given use data:uri. */
-            if ($self.attr("src") === undefined || $self.attr("src") === false) {
+            if ($self.attr("src") === undefined || $self.attr("src") === false || $self.attr("src").trim() === '') {
                 if ($self.is("img")) {
                     $self.attr("src", settings.placeholder);
                 }


### PR DESCRIPTION
In some templates, such as ERB for Rails, it will automatically generate a `<img>` tag likes:

``` html
<img class="lazy" data-original="something.jpg" height="180" src="" width="180">
```

so the plugin will not work because the `if` in https://github.com/tuupola/jquery_lazyload/blob/master/jquery.lazyload.js#L92

``` js
if ($self.attr("src") === undefined || $self.attr("src") === false)  {
```

will always be false, and the placeholder will not be shown.

I append a new case which considers a blank `src` attribute like `''`.
