### PR TITLE
added `handle_webkit_error` option to `settings`

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -29,7 +29,8 @@
             skip_invisible  : true,
             appear          : null,
             load            : null,
-            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC",
+            handle_webkit_error : false
         };
 
         function update() {
@@ -69,6 +70,12 @@
             }
 
             $.extend(settings, options);
+
+			/* the bug won't happen if we don't skip invisible */
+            if (settings.handle_webkit_error && !settings.skip_invisible) {
+            	settings.handle_webkit_error = null;
+            }
+
         }
 
         /* Cache container as jQuery as object. */
@@ -159,7 +166,14 @@
 
         /* Force initial check if images should appear. */
         $(document).ready(function() {
-            update();
+	        /* If we're dealing with a webkit browser, this hack comes in handy */
+			if (settings.handle_webkit_error && (/webkit/gi).test(navigator.appVersion)) {
+				$(window).scrollTop($(window).scrollTop()+1);
+	            update();
+	            $(window).scrollTop($(window).scrollTop()-1);
+			} else {
+	            update();
+	        }
         });
 
         return this;

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -71,11 +71,10 @@
 
             $.extend(settings, options);
 
-			/* the bug won't happen if we don't skip invisible */
+            /* the bug won't happen if we don't skip invisible */
             if (settings.handle_webkit_error && !settings.skip_invisible) {
-            	settings.handle_webkit_error = null;
+                settings.handle_webkit_error = null;
             }
-
         }
 
         /* Cache container as jQuery as object. */
@@ -166,14 +165,14 @@
 
         /* Force initial check if images should appear. */
         $(document).ready(function() {
-	        /* If we're dealing with a webkit browser, this hack comes in handy */
-			if (settings.handle_webkit_error && (/webkit/gi).test(navigator.appVersion)) {
-				$(window).scrollTop($(window).scrollTop()+1);
+            /* If we're dealing with a webkit browser, this hack comes in handy */
+            if (settings.handle_webkit_error && (/webkit/gi).test(navigator.appVersion)) {
+	            $(window).scrollTop($(window).scrollTop()+1);
 	            update();
 	            $(window).scrollTop($(window).scrollTop()-1);
-			} else {
+            } else {
 	            update();
-	        }
+            }
         });
 
         return this;


### PR DESCRIPTION
This addresses the behavior caused by webkit browsers reporting images without width/height as not visible if `skip_invisible` is false.  this seems to be a common issue on stack overflow and the comments section of the lazyload website.

reference lazyload website:

     HEADS UP! Webkit browsers will report images with without width and height as not .not(":visible"). This causes images to appear only when you scroll a bit. Either fix your image tags or set skip_invisible to false.

if a user has images of unknown dimensions ( like me! ) and wants to skip_invisible ( because they might have tabbed browsing enabled, like me! ), they can pass in `handle_webkit_error : true` to the lazyload settings.

this setting controls the initial `update` that occurs on `document.ready(`.  if `handle_webkit_error` is true ( tested first , so we quickly fail in a logical short-circuit ) we check the navigator.appVersion for the string "webkit".  if a "webkit" browser is detected, the plugin does a modified initial "update":

* scroll down 1 pixel
* update()
* scroll up 1 pixel

this seems to get past the bug/behavior in webkit.