### PR TITLE
Add Error callback for when images requests fail

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -29,6 +29,7 @@
             skip_invisible  : true,
             appear          : null,
             load            : null,
+            error           : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
         };
 
@@ -125,6 +126,19 @@
                             if (settings.load) {
                                 var elements_left = elements.length;
                                 settings.load.call(self, elements_left, settings);
+                            }
+                        }).bind("error", function() {
+                            self.error = true;
+
+                            /* Remove image from array so it is not looped next time. */
+                            var temp = $.grep(elements, function(element) {
+                                return !element.error;
+                            });
+                            elements = $(temp);
+
+                            if (settings.error) {
+                                var elements_left = elements.length;
+                                settings.error.call(self, elements_left, settings);
                             }
                         })
                         .attr("src", $self.attr("data-" + settings.data_attribute));


### PR DESCRIPTION
It would be nice to have a "failed" event too if image request failed. For instance in my app I am adding a ".loaded" class to images that have finished using the 'load' event and then for various reasons i am periodically checking to see if all images were loaded, but if an image failed '404' then my check runs infinitely. If there was a 'failed' event I could add a failed class or even a 'loaded' class, but something to know that the plugin itself ran, but the image request failed. Does that make sense?
