### PR TITLE
Fixing custom event behavior on page load

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -159,8 +159,9 @@
 
         /* Force initial check if images should appear. */
         $(document).ready(function() {
-            if (0 === settings.event.indexOf("scroll"))
-                update();
+            if (0 === settings.event.indexOf("scroll")) {
+				update();
+			}
         });
 
         return this;

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -159,7 +159,8 @@
 
         /* Force initial check if images should appear. */
         $(document).ready(function() {
-            update();
+            if (0 === settings.event.indexOf("scroll"))
+                update();
         });
 
         return this;

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -142,7 +142,9 @@
 
         /* Check if something appears when window is resized. */
         $window.bind("resize", function() {
-            update();
+            if (0 === settings.event.indexOf("scroll")) {
+                update();
+            }
         });
 
         /* With IOS5 force loading images when navigating with back button. */
@@ -160,8 +162,8 @@
         /* Force initial check if images should appear. */
         $(document).ready(function() {
             if (0 === settings.event.indexOf("scroll")) {
-				update();
-			}
+                update();
+            }
         });
 
         return this;

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -23,10 +23,11 @@
             threshold       : 0,
             failure_limit   : 0,
             event           : "scroll",
-            effect          : "show",
-            container       : window,
-            data_attribute  : "original",
-            skip_invisible  : true,
+			custom_event_immediate_load: true,
+			effect          : "show",
+			container       : window,
+			data_attribute  : "original",
+			skip_invisible  : true,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
@@ -142,7 +143,7 @@
 
         /* Check if something appears when window is resized. */
         $window.bind("resize", function() {
-            if (0 === settings.event.indexOf("scroll")) {
+            if (settings.custom_event_immediate_load || 0 === settings.event.indexOf("scroll")) {
                 update();
             }
         });
@@ -161,7 +162,7 @@
 
         /* Force initial check if images should appear. */
         $(document).ready(function() {
-            if (0 === settings.event.indexOf("scroll")) {
+			if (settings.custom_event_immediate_load || 0 === settings.event.indexOf("scroll")) {
                 update();
             }
         });


### PR DESCRIPTION
This pull request adds a new option to specify whether images with custom event for appearing should load immediately if they are on viewport. Default behavior is preserved, so this update is backward compatible. When you set `custom_event_immediate_load` to `false`, images with custom events will not load until the actual event is triggered.

~~Even when using custom event for image loading, images in viewport will still load right after page load as descbied here tuupola/jquery_lazyload#220.~~

~~This pull request fixes this behavior by checking if the desired event is "scroll" before calling update function on document ready. When one sets event to anything else, images won't load until the actual event is triggered.~~
