### PR TITLE
Common JS support

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -13,7 +13,13 @@
  *
  */
 
-(function($, window, document, undefined) {
+(function (factory) {
+  if(typeof module === "object" && typeof module.exports === "object") {
+    factory(require("jquery"), window, document);
+  } else {
+    factory(jQuery, window, document);
+  }
+}(function($, window, document, undefined) {
     var $window = $(window);
 
     $.fn.lazyload = function(options) {
@@ -239,4 +245,4 @@
         "left-of-fold"   : function(a) { return !$.rightoffold(a, {threshold : 0}); }
     });
 
-})(jQuery, window, document);
+}));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "jquery": "^2.1.3"
-  }
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/tuupola/jquery_lazyload/issues"
   },
   "homepage": "http://www.appelsiini.net/projects/lazyload",
+  "browser": {
+    "jquery-lazyload": "jquery.lazyload.js"
+  },
   "main": "Gruntfile.js",
   "files": [
       "jquery.lazyload.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "jquery": "^2.1.3"
+  }
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.4",


### PR DESCRIPTION
Currently to use this plugin in Node/Browserify and create bundles, something like the following needs to be done:

```
global.jQuery = window.$ = require('jquery');
require('jquery-lazyload/jquery.lazyload');
```

Instead, the correct way to avoid global namespace pollution and using CJS would be

```
require('jquery-lazyload')
```

This PR tries to address that by making the plugin be available as a Common JS module in addition to being a global module
