### PR TITLE
Fetch image original either from data-original, or content or contentUrl attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ $("img.lazy").lazyload();
 
 This causes all images of class lazy to be lazy loaded.
 
+If you have adopted microformats ([schema.org](https://schema.org/ImageObject)'s example):
+```
+<img class="lazy" itemprop="image" contentUrl="img/example.jpg" width="640" height="480">
+```
+
+then in your code do:
+
+```
+$("img.lazy").lazyload({attribute: "contentUrl"});
+```
+
 More information on [Lazy Load](http://www.appelsiini.net/projects/lazyload) project page.
 
 ## Install

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -26,6 +26,7 @@
             effect          : "show",
             container       : window,
             data_attribute  : "original",
+            attribute       : "contentUrl",
             skip_invisible  : false,
             appear          : null,
             load            : null,
@@ -55,6 +56,10 @@
                 }
             });
 
+        }
+
+        function getOriginal($e) {
+            return $e.attr("data-" + settings.data_attribute) || $e.attr(settings.attribute);
         }
 
         if(options) {
@@ -98,6 +103,8 @@
             /* When appear is triggered load original image. */
             $self.one("appear", function() {
                 if (!this.loaded) {
+                    var original = getOriginal($self);
+
                     if (settings.appear) {
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
@@ -105,7 +112,6 @@
                     $("<img />")
                         .bind("load", function() {
 
-                            var original = $self.attr("data-" + settings.data_attribute);
                             $self.hide();
                             if ($self.is("img")) {
                                 $self.attr("src", original);
@@ -127,7 +133,7 @@
                                 settings.load.call(self, elements_left, settings);
                             }
                         })
-                        .attr("src", $self.attr("data-" + settings.data_attribute));
+                        .attr("src", original);
                 }
             });
 


### PR DESCRIPTION
As microformats keep gaining traction, having attributes that describe better the page, and its information, becomes more and more relevant.

Many "objects" (movie, product, person, etc) can have a photo, which can be tag as itemprop="image". Normally if the element is an IMG the parser would refer to the SRC to know the content of that property. Since with lazy loading we lack that, other attributes can be used: content or contentUrl.

To avoid duplication of <img data-original=etc_etc_etc itemprop=image content=etc_etc_etc> one could assume that a missing data-original implies the usage of content, or contentUrl to fetch the original image.

Thoughts?
