### PR TITLE
Include *.min.js in Bower package and ! in license comment

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
-    "**/*.min.js",
     "**/*.html",
     "**/*.textile",
     "Gruntfile.js",

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -1,4 +1,4 @@
-/*
+/* @license
  * Lazy Load - jQuery plugin for lazy loading images
  *
  * Copyright (c) 2007-2013 Mika Tuupola

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -1,4 +1,4 @@
-/* @license
+/*!
  * Lazy Load - jQuery plugin for lazy loading images
  *
  * Copyright (c) 2007-2013 Mika Tuupola


### PR DESCRIPTION
This pull request includes a `!` in the license comment so that it will be preserved in minified output. Also included minified JS in the Bower package, so the user can simply include the plugin-author minified version if desired.