### PR TITLE
Namespace window resize event, so it may be elegantly unbound

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -143,7 +143,7 @@
         });
 
         /* Check if something appears when window is resized. */
-        $window.bind("resize", function() {
+        $window.bind("resize.jqlazyload", function() {
             update();
         });
 


### PR DESCRIPTION
With pages that require high performance, sometimes with many high-resolution images being rendered concurrently, it's important to be able to debounce the internal `update` call/check.

Currently this *can* be achieved for scrolling (or other rapid-fire events) by passing a custom callback method to the plugin's `event` setting, and any debouncing magic could be handled (with your utility lib of choice) prior to triggering said event.

However, window resize *cannot* currently be debounced, as is. It's not possible to unbind the resize event that is directly set on the window without actually clobbering any other resize events also attached (perhaps by other libs).

For a simple fix, we can namespace the plugin resize event to allow for easy unbinding where necessary. For example, any window resize debouncing magic could be handled prior to calling the custom `event`.