### PR TITLE
bind => on

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -103,8 +103,7 @@
                         settings.appear.call(self, elements_left, settings);
                     }
                     $("<img />")
-                        .bind("load", function() {
-
+                        .one("load", function() {
                             var original = $self.attr("data-" + settings.data_attribute);
                             $self.hide();
                             if ($self.is("img")) {

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -77,7 +77,7 @@
 
         /* Fire one scroll event per scroll. Not one scroll event per image. */
         if (0 === settings.event.indexOf("scroll")) {
-            $container.bind(settings.event, function() {
+            $container.on(settings.event, function() {
                 return update();
             });
         }
@@ -134,7 +134,7 @@
             /* When wanted event is triggered load original image */
             /* by triggering appear.                              */
             if (0 !== settings.event.indexOf("scroll")) {
-                $self.bind(settings.event, function() {
+                $self.on(settings.event, function() {
                     if (!self.loaded) {
                         $self.trigger("appear");
                     }
@@ -143,14 +143,14 @@
         });
 
         /* Check if something appears when window is resized. */
-        $window.bind("resize", function() {
+        $window.on("resize", function() {
             update();
         });
 
         /* With IOS5 force loading images when navigating with back button. */
         /* Non optimal workaround. */
         if ((/(?:iphone|ipod|ipad).*os 5/gi).test(navigator.appVersion)) {
-            $window.bind("pageshow", function(event) {
+            $window.on("pageshow", function(event) {
                 if (event.originalEvent && event.originalEvent.persisted) {
                     elements.each(function() {
                         $(this).trigger("appear");


### PR DESCRIPTION
This work has the eventual goal of exposing a teardown fn inside of lazyload.
On single page applications where your DOM is transient and you do not have the saving grace of a page reload between each navigation, it is desirable to be able to tear down event listeners because they cause nodes to be retained and never garbage collected.

This PR initially migrates us from bind => on, and bind => one
The next steps will be to namespace all of the events and then expose an `.destroy` fn

refs:
https://github.com/tuupola/jquery_lazyload/pull/194
https://github.com/tuupola/jquery_lazyload/issues/96
https://github.com/tuupola/jquery_lazyload/pull/135
https://github.com/tuupola/jquery_lazyload/issues/62
https://github.com/tuupola/jquery_lazyload/pull/133


Profling:
https://www.youtube.com/watch?v=OLWEyH7_4e0


--------

Thx again for the great work!