### PR TITLE
Use transparent gif instead of png

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -29,7 +29,7 @@
             skip_invisible  : false,
             appear          : null,
             load            : null,
-            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+            placeholder     : "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
         };
 
         function update() {


### PR DESCRIPTION
Use a transparent gif for the placeholder. It has a much smaller string representation.