### PR TITLE
Prevent flickers for already loaded images.

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -23,13 +23,20 @@
             threshold       : 0,
             failure_limit   : 0,
             event           : "scroll",
-            effect          : "show",
+            effect          : $.noop,
             container       : window,
             data_attribute  : "original",
             skip_invisible  : false,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+        };
+
+        var effectFromString = function(effect) {
+          return function($el) {
+            $el.hide();
+            $el[settings.effect](settings.effect_speed);
+          };
         };
 
         function update() {
@@ -102,31 +109,52 @@
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
                     }
-                    $("<img />")
-                        .one("load", function() {
-                            var original = $self.attr("data-" + settings.data_attribute);
-                            $self.hide();
-                            if ($self.is("img")) {
-                                $self.attr("src", original);
-                            } else {
-                                $self.css("background-image", "url('" + original + "')");
-                            }
-                            $self[settings.effect](settings.effect_speed);
 
-                            self.loaded = true;
+                    var src = $self.attr("data-" + settings.data_attribute);
 
-                            /* Remove image from array so it is not looped next time. */
-                            var temp = $.grep(elements, function(element) {
-                                return !element.loaded;
-                            });
-                            elements = $(temp);
+                    var swapImage = function(noFx) {
+                      var original = $self.attr("data-" + settings.data_attribute);
+                      if ($self.is("img")) {
+                        $self.attr("src", original);
+                      } else {
+                        $self.css("background-image", "url('" + original + "')");
+                      }
+                      if (!noFx) {
+                        var effect = settings.effect;
 
-                            if (settings.load) {
-                                var elements_left = elements.length;
-                                settings.load.call(self, elements_left, settings);
-                            }
-                        })
-                        .attr("src", $self.attr("data-" + settings.data_attribute));
+                        if ($.type(effect) === "string") {
+                          effect = effectFromString(effect);
+                        }
+
+                        effect($self);
+                      }
+
+                      self.loaded = true;
+
+                      /* Remove image from array so it is not looped next time. */
+                      var temp = $.grep(elements, function(element) {
+                        return !element.loaded;
+                      });
+                      elements = $(temp);
+
+                      if (settings.load) {
+                        var elements_left = elements.length;
+                        settings.load.call(self, elements_left, settings);
+                      }
+                    };
+
+                    var $img = $("<img />")
+                        .attr("src", src);
+
+                    if ($img[0].complete) {
+                      // Appear immediately without effects
+                      swapImage(true);
+                    } else {
+                      // Wait for load event, allow effects
+                      $img.one("load", function() {
+                        swapImage();
+                      });
+                    }
                 }
             });
 


### PR DESCRIPTION
Large single-page apps, like Ember, will sometimes rerender the same element with the same image. This can cause lots of flickering with lazyload.

Also, an image reused throughout the page (say, an avatar) fades in every single time, which can make for a jumpy experience (esp. if a rerender is triggered).

Last, the start of the animation is hardwired to `hide()`, which unnecessarily causes page reflow issues even when the dimensions are known.

To fix this, `settings.effect` accepts a function, which defaults to a noop (preventing flickering for folks without any effect specified), and the effects are never run if the image is already cached. If `settings.effect` is a string, it gets converted to a function as before, so it should be backwards compatible.

For my specific use case, this lets me just use `$el.css({opacity: 0}).animate({opacity: 1});` as my effect, which doesn't cause a page reflow or flicker.

Tested in Firefox and Chrome.

Easier to see relevant changes with the `?w=1` flag.