### PR TITLE
Remove the lazyload data attribute after the image has been loaded

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -125,6 +125,8 @@
                                 var elements_left = elements.length;
                                 settings.load.call(self, elements_left, settings);
                             }
+
+                            $self.removeAttr("data-" + settings.data_attribute);
                         })
                         .attr("src", $self.attr("data-" + settings.data_attribute));
                 }


### PR DESCRIPTION
By removing the lazyload data attribute after loading the image we can select those image with a CSS selector :not([data-original]).

This is especially useful when images are flexible (width: 100%, height: auto).

Currently there is a bug if the images are of flexible width with height set to auto. When the base64 encoded placeholder is placed, the height: auto makes the height the same amount as width, because it's a 1 per 1 pixel image. That makes the page jump when you scroll the page down to top (try to scroll down on a page, and then hit refresh).

With this feature, we can apply the height: auto only to "loaded" images and that will fix this issue.