### PR TITLE
Feature/Bugfix: Cacheable -- Double Requested Resources

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -103,8 +103,10 @@
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
                     }
-                    $("<img />")
-                        .one("load", function() {
+
+                    if (!settings.quick_swap) {
+                        $("<img />")
+                        .bind("load", function() {
                             var original = $self.attr("data-" + settings.data_attribute);
                             $self.hide();
                             if ($self.is("img")) {
@@ -128,6 +130,28 @@
                             }
                         })
                         .attr("src", $self.attr("data-" + settings.data_attribute));
+                    } else {
+                        $("<img />").attr("src", $self.attr("data-" + settings.data_attribute));
+                        var original = $self.attr("data-" + settings.data_attribute);
+                        if ($self.is("img")) {
+                            $self.attr("src", original);
+                        } else {
+                            $self.css("background-image", "url('" + original + "')");
+                        }
+
+                        self.loaded = true;
+
+                        /* Remove image from array so it is not looped next time. */
+                        var temp = $.grep(elements, function(element) {
+                            return !element.loaded;
+                        });
+                        elements = $(temp);
+
+                        if (settings.load) {
+                            var elements_left = elements.length;
+                            settings.load.call(self, elements_left, settings);
+                        }
+                    }
                 }
             });
 

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -27,6 +27,7 @@
             container       : window,
             data_attribute  : "original",
             skip_invisible  : false,
+            quick_swap      : false,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -131,7 +131,6 @@
                         })
                         .attr("src", $self.attr("data-" + settings.data_attribute));
                     } else {
-                        $("<img />").attr("src", $self.attr("data-" + settings.data_attribute));
                         var original = $self.attr("data-" + settings.data_attribute);
                         if ($self.is("img")) {
                             $self.attr("src", original);

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -27,7 +27,7 @@
             container       : window,
             data_attribute  : "original",
             skip_invisible  : false,
-            preload         : true,
+            cacheable       : true,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
@@ -103,10 +103,8 @@
                         var elements_left = elements.length;
                         settings.appear.call(self, elements_left, settings);
                     }
-
-                    if (settings.preload) {
-                        $("<img />")
-                        .bind("load", function() {
+                    if (settings.cacheable) {
+                        $("<img />").one("load", function() {
                             var original = $self.attr("data-" + settings.data_attribute);
                             $self.hide();
                             if ($self.is("img")) {

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -27,7 +27,7 @@
             container       : window,
             data_attribute  : "original",
             skip_invisible  : false,
-            quick_swap      : false,
+            preload         : true,
             appear          : null,
             load            : null,
             placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
@@ -104,7 +104,7 @@
                         settings.appear.call(self, elements_left, settings);
                     }
 
-                    if (!settings.quick_swap) {
+                    if (settings.preload) {
                         $("<img />")
                         .bind("load", function() {
                             var original = $self.attr("data-" + settings.data_attribute);


### PR DESCRIPTION
When working with impression-trackers we are requesting resources with insanely aggressive no-cache policies, yet, they still need to be lazy loaded.

This plugin does not play friendly with non-cacheable resources. It requests them twice due to the way it utilizes `load` callbacks to trigger the swapping of `src` with `data-img-src`.

When `cacheable` is set to false it removes the `bind` on `load` in order to ensure we make 1 and only 1 request for the resource. 

We simply write to the `src` attribute and call it a day, nothing fancy, no animations.
