### PR TITLE
Leaks fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $("img.lazy").lazyload();
 
 This causes all images of class lazy to be lazy loaded.
 
+For destroying event listeners:
+
+```js
+$("img.lazy").lazyload.destroy();
+```
+
 More information on [Lazy Load](http://www.appelsiini.net/projects/lazyload) project page.
 
 ## Install
@@ -45,4 +51,3 @@ $ npm install jquery-lazyload
 # License
 
 All code licensed under the [MIT License](http://www.opensource.org/licenses/mit-license.php). All images licensed under [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US). In other words you are basically free to do whatever you want. Just don't remove my name from the source.
-

--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -18,6 +18,7 @@
 
     $.fn.lazyload = function(options) {
         var elements = this;
+        var eventNameSpace = '.lazyload';
         var $container;
         var settings = {
             threshold       : 0,
@@ -57,6 +58,18 @@
 
         }
 
+        $.fn.lazyload.destroy = function() {
+            $window.off(eventNameSpace);
+            $container.off(eventNameSpace);
+
+            elements.each(function() {
+                var self = this;
+                var $self = $(self);
+
+                $self.off(eventNameSpace);
+            });
+        }
+
         if(options) {
             /* Maintain BC for a couple of versions. */
             if (undefined !== options.failurelimit) {
@@ -77,7 +90,7 @@
 
         /* Fire one scroll event per scroll. Not one scroll event per image. */
         if (0 === settings.event.indexOf("scroll")) {
-            $container.on(settings.event, function() {
+            $container.on(settings.event + eventNameSpace, function() {
                 return update();
             });
         }
@@ -133,7 +146,7 @@
             /* When wanted event is triggered load original image */
             /* by triggering appear.                              */
             if (0 !== settings.event.indexOf("scroll")) {
-                $self.on(settings.event, function() {
+                $self.on(settings.event + eventNameSpace, function() {
                     if (!self.loaded) {
                         $self.trigger("appear");
                     }
@@ -142,14 +155,14 @@
         });
 
         /* Check if something appears when window is resized. */
-        $window.on("resize", function() {
+        $window.on("resize" + eventNameSpace, function() {
             update();
         });
 
         /* With IOS5 force loading images when navigating with back button. */
         /* Non optimal workaround. */
         if ((/(?:iphone|ipod|ipad).*os 5/gi).test(navigator.appVersion)) {
-            $window.on("pageshow", function(event) {
+            $window.on("pageshow" + eventNameSpace, function(event) {
                 if (event.originalEvent && event.originalEvent.persisted) {
                     elements.each(function() {
                         $(this).trigger("appear");


### PR DESCRIPTION
Added:
- event namespace
- destroy method

**TL;TR**

I created simple example and made some profiling. 

![mojotech html 2016-11-04 12-58-45](https://cloud.githubusercontent.com/assets/6231516/20004303/290a1d90-a294-11e6-9e56-f1e90474e866.png)

![mojotech html 2016-11-04 13-17-29](https://cloud.githubusercontent.com/assets/6231516/20004391/cf5656a0-a294-11e6-9262-85e4a4ef5e5c.png)

[Here](https://jsfiddle.net/wd5h8400/) some example, which I used but I've done all work locally to reduce influence by jsfiddle or smth.

After destroying container with images, number of listeners more then at the beginning, also if look a second screen `resize`, `scroll` event listeners are present. 

Another problem is `namespaces`, if we want to do destroy it's not possible without events namespaces.

So results of implemented solution are below and example is [here](https://jsfiddle.net/cr6gb8mq/).

![mojotech html 2016-11-04 13-08-04](https://cloud.githubusercontent.com/assets/6231516/20004624/2bd68052-a296-11e6-9b7b-89d30aea184d.png)

![mojotech html 2016-11-04 13-11-51](https://cloud.githubusercontent.com/assets/6231516/20004627/2f592ba8-a296-11e6-9bb1-f54f41426cdb.png)




