### PR TITLE
jQuery 3.x support: $(document).ready(fn) replaced with $(fn)

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -159,7 +159,7 @@
         }
 
         /* Force initial check if images should appear. */
-        $(document).ready(function() {
+        $(function() {
             update();
         });
 


### PR DESCRIPTION
as it's deprecated in jQuery 3.x - see https://jquery.com/upgrade-guide/3.0/#deprecated-document-ready-handlers-other-than-jquery-function