### PR TITLE
Avoid flickering in subsequent calls to `.lazyload()`.

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -89,11 +89,16 @@
             self.loaded = false;
 
             /* If no src attribute given use data:uri. */
-            if ($self.attr("src") === undefined || $self.attr("src") === false) {
-                if ($self.is("img")) {
+            if ($self.is("img")) {
+                if ($self.attr("src") === undefined || $self.attr("src") === false) {
                     $self.attr("src", settings.placeholder);
                 }
+            } else {
+                if (!$self.css("background-image")) {
+                    $self.css("background-image", "url('" + settings.placeholder + "')");
+                }
             }
+
 
             /* When appear is triggered load original image. */
             $self.one("appear", function() {


### PR DESCRIPTION
Avoid flickering in subsequent calls to `.lazyload()` on items different than `<img>` that have already been loaded.

The check on the `src` attribute was done even on elements that won't have this attribute set (for elements that are not images).