### PR TITLE
:bug: fix amd support

### DIFF
--- a/lazyload.js
+++ b/lazyload.js
@@ -17,13 +17,17 @@
     if (typeof exports === "object") {
         module.exports = factory(root);
     } else if (typeof define === "function" && define.amd) {
-        define([], factory(root));
+        define([], factory);
     } else {
         root.LazyLoad = factory(root);
     }
 }) (typeof global !== "undefined" ? global : this.window || this.global, function (root) {
 
     "use strict";
+
+    if (typeof define === "function" && define.amd){
+        root = window;
+    }
 
     const defaults = {
         src: "data-src",


### PR DESCRIPTION
in requirejs ,we will create a module like this
```javascript
define([],function(){
})
```
so in umd ,you should just send the function name,if you send the function,code will be run as this
```javascript
LazyLoad()
```
but LazyLoad is a constructor function,if you don't use new,this will be undefined in strict mode