### PR TITLE
added quotes when assigning url('')

### DIFF
--- a/lazyload.js
+++ b/lazyload.js
@@ -118,7 +118,7 @@
                                 entry.target.srcset = srcset;
                             }
                         } else {
-                            entry.target.style.backgroundImage = "url(" + src + ")";
+                            entry.target.style.backgroundImage = "url('" + src + "')";
                         }
                     }
                 });


### PR DESCRIPTION
Added quotes because without them some images (e.g. with parenthesis in name) arent loaded properly